### PR TITLE
Fix typo on config to disable color highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For color highlight:
 let g:everblushNR=1 " default
 
 " To disable
-let g:everblushNR=1
+let g:everblushNR=0
 
 " Remember to reload colorscheme after changing the variable
 ```


### PR DESCRIPTION
Thanks for the beautiful theme. I just find a typo on the `README`. 