### PR TITLE
Change floating value color in C and make quickfix line text more readable

### DIFF
--- a/colors/everblush.vim
+++ b/colors/everblush.vim
@@ -105,7 +105,7 @@ hi PmenuThumb guifg=NONE guibg=#8ccf7e gui=NONE cterm=NONE
 hi PreCondit guifg=#c47fd5 guibg=NONE gui=NONE cterm=NONE
 hi PreProc guifg=#67b0e8 guibg=NONE gui=NONE cterm=NONE
 hi Question guifg=#c47fd5 guibg=NONE gui=NONE cterm=NONE
-hi QuickFixLine guifg=NONE guibg=#8ccf7e gui=NONE cterm=NONE
+hi QuickFixLine guifg=#232a2d guibg=#8ccf7e gui=NONE cterm=NONE
 hi Repeat guifg=#c47fd5 guibg=NONE gui=NONE cterm=NONE
 hi Search guifg=#67b0e8 guibg=#2d3437 gui=NONE cterm=NONE
 hi SignColumn guifg=NONE guibg=#232a2d gui=NONE cterm=NONE

--- a/colors/everblush.vim
+++ b/colors/everblush.vim
@@ -330,7 +330,7 @@ hi cCppString guifg=#8ccf7e guibg=NONE gui=NONE cterm=NONE
 hi cCurlyError guifg=#b3b9b8 guibg=#ef7e7e gui=NONE cterm=NONE
 hi cErrInBracket guifg=#b3b9b8 guibg=#ef7e7e gui=NONE cterm=NONE
 hi cErrInParen guifg=#b3b9b8 guibg=#ef7e7e gui=NONE cterm=NONE
-hi cFloat guifg=#2d3437 guibg=NONE gui=NONE cterm=NONE
+hi cFloat guifg=#6cbfbf guibg=NONE gui=NONE cterm=NONE
 hi cFormat guifg=#67b0e8 guibg=NONE gui=NONE cterm=NONE
 hi cMutli guifg=#e5c76b guibg=NONE gui=NONE cterm=NONE
 hi cOperator guifg=#67b0e8 guibg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
### Change 0
Floating value in C code was dark. Now it's the same color as other numerical value.
[![float.gif](https://i.postimg.cc/vTnF8zWP/ezgif-com-gif-maker.gif)](https://postimg.cc/8fTntLXW)

### Change 1
The quickfix line text was bright on a bright bg. Now it's dark.
[![quickfixline.gif](https://i.postimg.cc/VspkY0W0/quickfixline.gif)](https://postimg.cc/0rGsnQ39)